### PR TITLE
Add support for Properties file format

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 gversion-plugin is a Gradle plugin for auto-generating a version class/file in multiple JVM Languages. Support provided 
-for Java, Kotlin, and YAML. The class will include information which can only be obtained at compile time, such as 
+for Java, Kotlin, YAML and Properties. The class will include information which can only be obtained at compile time, such as 
 build time, git SHA, and Gradle version. Command line applications are used to gather most of this information. 
 If a command line operation fails a default value will be used instead. This has been tested in Linux, Windows, and Mac OS X.
 
@@ -19,7 +19,7 @@ gversion {
   dateFormat   = "yyyy-MM-dd'T'HH:mm:ss'Z'" // optional. This is the default
   timeZone     = "UTC"                      // optional. UTC is default
   debug        = false                      // optional. print out extra debug information
-  language     = "java"                     // optional. Can be Java, Kotlin, or YAML. Case insensitive.
+  language     = "java"                     // optional. Can be Java, Kotlin, YAML, or Properties. Case insensitive.
   explicitType = false                      // optional. Force types to be explicitly printed
   indent       = "\t"                       // optional. Change how code is indented. 1 tab is default.
   annotate     = false                      // optional. Java only. Adds @Generated annotation

--- a/src/main/groovy/com/peterabeles/GVersion.groovy
+++ b/src/main/groovy/com/peterabeles/GVersion.groovy
@@ -10,13 +10,15 @@ import java.text.SimpleDateFormat
 enum Language {
     YAML,
     JAVA,
-    KOTLIN;
+    KOTLIN,
+    PROPERTIES;
 
     static Language convert(String name) {
         switch (name.toUpperCase()) {
             case "JAVA": return JAVA
             case "KOTLIN": return KOTLIN
             case "YAML": return YAML
+            case "PROPERTIES": return PROPERTIES
         }
         throw new IllegalArgumentException("Unknown language. " + name)
     }
@@ -318,6 +320,22 @@ class GVersion implements Plugin<Project> {
                         writer << "BUILD_DATE: \"$date_string\"\n"
                         writer << "BUILD_UNIX_TIME: $unix_time\n"
                         writer << "DIRTY: $dirty_value\n"
+                        writer.flush()
+                    }
+                } else if (language == Language.PROPERTIES) {
+                    new File(gversion_file_path, extension.className).withWriter { writer ->
+                        writer << "#Created by build system. Do not modify\n"
+                        writer << "#\"$date_string\"\n"
+                        writer << "version=\"$project.version\"\n"
+                        writer << "revision=$git_revision\n"
+                        writer << "name=\"$project.name\"\n"
+                        writer << "timestamp=$unix_time\n"
+                        writer << "group=\"$project.group\"\n"
+                        writer << "sha=\"$git_sha\"\n"
+                        writer << "git_date=\"$git_date\"\n"
+                        writer << "git_branch=\"$git_branch\"\n"
+                        writer << "build_date=\"$date_string\"\n"
+                        writer << "dirty=$dirty_value\n"
                         writer.flush()
                     }
                 } else {


### PR DESCRIPTION
I needed to generate a file similar to what was generated by the buildnumber-maven-plugin. Unfortunately there wasn't anything similar for Gradle, but I found your plugin and modified the code so it can generate properties files too. You can see an example output below. If you're happy with it please merge it into the code.

```
#Created by build system. Do not modify
#"2020-11-24T14:46:27Z"
version="0.10.0.7.2.7.0-SNAPSHOT"
revision=1018
name="registry-client"
timestamp=1606229187761
group="com.registries"
sha="779af3619473de02c5709440c2c7ed7ecc9d7d3b"
git_date="2020-11-23T19:11:06Z"
git_branch="rewrite-build-no"
build_date="2020-11-24T14:46:27Z"
dirty=1
```

@lessthanoptimal 