### PR TITLE
Remove double quotes from values in properties files.

### DIFF
--- a/src/main/groovy/com/peterabeles/GVersion.groovy
+++ b/src/main/groovy/com/peterabeles/GVersion.groovy
@@ -340,16 +340,16 @@ class GVersion implements Plugin<Project> {
                 } else if (language == Language.PROPERTIES) {
                     new File(gversion_file_path, extension.className).withWriter { writer ->
                         writer << "#Created by build system. Do not modify\n"
-                        writer << "#\"$date_string\"\n"
-                        writer << "version=\"$project.version\"\n"
+                        writer << "#$date_string\n"
+                        writer << "version=$project.version\n"
                         writer << "revision=$git_revision\n"
-                        writer << "name=\"$project.name\"\n"
+                        writer << "name=$project.name\n"
                         writer << "timestamp=$unix_time\n"
-                        writer << "group=\"$project.group\"\n"
-                        writer << "sha=\"$git_sha\"\n"
-                        writer << "git_date=\"$git_date\"\n"
-                        writer << "git_branch=\"$git_branch\"\n"
-                        writer << "build_date=\"$date_string\"\n"
+                        writer << "group=$project.group\n"
+                        writer << "sha=$git_sha\n"
+                        writer << "git_date=$git_date\n"
+                        writer << "git_branch=$git_branch\n"
+                        writer << "build_date=$date_string\n"
                         writer << "dirty=$dirty_value\n"
                         writer.flush()
                     }


### PR DESCRIPTION
[Java's property loader](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-) includes everything after the equals sign in the value. This resulted in values that were surrounded by quotes.